### PR TITLE
Feature/base reporter

### DIFF
--- a/circle_evolution/evolution.py
+++ b/circle_evolution/evolution.py
@@ -96,7 +96,4 @@ class Evolution(Runner):
             if newfit > fit:
                 fit = newfit
                 self.specie = mutated
-                self.notify(
-                    f"Generation {self.generation}\t"
-                    f"Fitness: {newfit}"
-                )
+                self.notify(f"Generation {self.generation}\t" f"Fitness: {newfit}")

--- a/circle_evolution/evolution.py
+++ b/circle_evolution/evolution.py
@@ -6,12 +6,12 @@ import numpy as np
 
 import circle_evolution.fitness as fitness
 
-from circle_evolution.runner import Runner
+from circle_evolution import runner
 
 from circle_evolution.species import Specie
 
 
-class Evolution(Runner):
+class Evolution(runner.Runner):
     """Logic for a Species Evolution.
 
     Use the Evolution class when you want to train a Specie to look like
@@ -37,7 +37,7 @@ class Evolution(Runner):
         self.target = target  # Target Image
         self.generation = 1
         self.genes = genes
-        self.current_fitness = None
+        self.best_fit = self.new_fit = 0
 
         self.specie = Specie(size=self.size, genes=genes)
 
@@ -82,19 +82,22 @@ class Evolution(Runner):
             fitness (fitness.Fitness): fitness class to score species preformance.
             max_generation (int): amount of generations to train for.
         """
+        self.notify(self, runner.START)
         fitness_ = fitness(self.target)
 
         self.specie.render()
-        self.current_fitness = fitness_.score(self.specie.phenotype)
+        self.best_fit = fitness_.score(self.specie.phenotype)
 
-        for i in range(max_generation):
+        for i in range(0, max_generation):
             self.generation = i + 1
 
             mutated = self.mutate(self.specie)
             mutated.render()
-            newfit = fitness_.score(mutated.phenotype)
+            self.new_fit = fitness_.score(mutated.phenotype)
+            self.notify(self)
 
-            if newfit > self.current_fitness:
-                self.current_fitness = newfit
+            if self.new_fit > self.best_fit:
+                self.best_fit = self.new_fit
                 self.specie = mutated
-                self.notify(self)
+
+        self.notify(self, runner.END)

--- a/circle_evolution/evolution.py
+++ b/circle_evolution/evolution.py
@@ -4,12 +4,14 @@ import random
 
 import numpy as np
 
-from circle_evolution.species import Specie
-
 import circle_evolution.fitness as fitness
 
+from circle_evolution.runner import Runner
 
-class Evolution:
+from circle_evolution.species import Specie
+
+
+class Evolution(Runner):
     """Logic for a Species Evolution.
 
     Use the Evolution class when you want to train a Specie to look like
@@ -70,14 +72,6 @@ class Evolution:
 
         return new_specie
 
-    def print_progress(self, fit):
-        """Prints progress of Evolution.
-
-        Args:
-            fit (float): fitness value of specie.
-        """
-        print("GEN {}, FIT {:.8f}".format(self.generation, fit))
-
     def evolve(self, fitness=fitness.MSEFitness, max_generation=100000):
         """Genetic Algorithm for evolution.
 
@@ -87,19 +81,22 @@ class Evolution:
             fitness (fitness.Fitness): fitness class to score species preformance.
             max_generation (int): amount of generations to train for.
         """
-        fitness = fitness(self.target)
+        fitness_ = fitness(self.target)
 
         self.specie.render()
-        fit = fitness.score(self.specie.phenotype)
+        fit = fitness_.score(self.specie.phenotype)
 
         for i in range(max_generation):
             self.generation = i + 1
 
             mutated = self.mutate(self.specie)
             mutated.render()
-            newfit = fitness.score(mutated.phenotype)
+            newfit = fitness_.score(mutated.phenotype)
 
             if newfit > fit:
                 fit = newfit
                 self.specie = mutated
-                self.print_progress(newfit)
+                self.notify(
+                    f"Generation {self.generation}\t"
+                    f"Fitness: {newfit}"
+                )

--- a/circle_evolution/evolution.py
+++ b/circle_evolution/evolution.py
@@ -37,6 +37,7 @@ class Evolution(Runner):
         self.target = target  # Target Image
         self.generation = 1
         self.genes = genes
+        self.current_fitness = None
 
         self.specie = Specie(size=self.size, genes=genes)
 
@@ -84,7 +85,7 @@ class Evolution(Runner):
         fitness_ = fitness(self.target)
 
         self.specie.render()
-        fit = fitness_.score(self.specie.phenotype)
+        self.current_fitness = fitness_.score(self.specie.phenotype)
 
         for i in range(max_generation):
             self.generation = i + 1
@@ -93,7 +94,7 @@ class Evolution(Runner):
             mutated.render()
             newfit = fitness_.score(mutated.phenotype)
 
-            if newfit > fit:
-                fit = newfit
+            if newfit > self.current_fitness:
+                self.current_fitness = newfit
                 self.specie = mutated
-                self.notify(f"Generation {self.generation}\t" f"Fitness: {newfit}")
+                self.notify(self)

--- a/circle_evolution/fitness.py
+++ b/circle_evolution/fitness.py
@@ -48,6 +48,7 @@ class MSEFitness(Fitness):
 
     See: https://en.wikipedia.org/wiki/Mean_squared_error.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._max_error = (np.square((1 - (self.target >= 127)) * 255 - self.target)).mean(axis=None)

--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -8,6 +8,8 @@ from circle_evolution.evolution import Evolution
 
 import circle_evolution.helpers as helpers
 
+from circle_evolution.reporter import LoggerReporter
+
 
 def main():
     """Entrypoint of application"""
@@ -21,8 +23,11 @@ def main():
     args = parser.parse_args()
 
     target = helpers.load_target_image(args.image, size=size_options[args.size])
+    reporter_logger = LoggerReporter()
 
     evolution = Evolution(size_options[args.size], target, genes=args.genes)
+    evolution.attach(reporter_logger)
+
     evolution.evolve(max_generation=args.max_generations)
 
     evolution.specie.render()

--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -8,7 +8,7 @@ from circle_evolution.evolution import Evolution
 
 import circle_evolution.helpers as helpers
 
-from circle_evolution.reporter import LoggerReporter
+from circle_evolution.reporter import LoggerMetricReporter
 
 
 def main():
@@ -23,7 +23,7 @@ def main():
     args = parser.parse_args()
 
     target = helpers.load_target_image(args.image, size=size_options[args.size])
-    reporter_logger = LoggerReporter()
+    reporter_logger = LoggerMetricReporter()
 
     evolution = Evolution(size_options[args.size], target, genes=args.genes)
     evolution.attach(reporter_logger)

--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -8,7 +8,7 @@ from circle_evolution.evolution import Evolution
 
 import circle_evolution.helpers as helpers
 
-from circle_evolution.reporter import LoggerMetricReporter
+from circle_evolution import reporter
 
 
 def main():
@@ -23,10 +23,12 @@ def main():
     args = parser.parse_args()
 
     target = helpers.load_target_image(args.image, size=size_options[args.size])
-    reporter_logger = LoggerMetricReporter()
+    reporter_logger = reporter.LoggerMetricReporter()
+    reporter_csv = reporter.CSVMetricReporter()
 
     evolution = Evolution(size_options[args.size], target, genes=args.genes)
     evolution.attach(reporter_logger)
+    evolution.attach(reporter_csv)
 
     evolution.evolve(max_generation=args.max_generations)
 

--- a/circle_evolution/reporter.py
+++ b/circle_evolution/reporter.py
@@ -1,0 +1,85 @@
+"""Reporters for capturing events and notifying the user about them.
+
+You can make your own Reporter class or use the already implemented one's.
+Notice the abstract class before implementing your Reporter to see which
+functions should be implemented.
+"""
+from abc import ABC, abstractmethod
+
+import logging
+import logging.config
+
+
+class Reporter(ABC):
+    """Base Reporter class.
+
+    The Reporter is responsible for capturing particular events and sending
+    them for visualization. Please, use this class if you want to implement
+    your own Reporter.
+    """
+    def __init__(self):
+        """Initialization calls setup to configure Reporter"""
+        self.setup()
+
+    def setup(self):
+        """Function for configuring the reporter.
+
+        Some reporters may need configuring some internal parameters or even
+        creating objects to warmup. This function deals with this
+        """
+
+    @abstractmethod
+    def update(self, report):
+        """Receives report from subject.
+
+        This is the main function for reporting events. The Reporter receives a
+        report and have to deal with what to do with that. For Circle-Evolution
+        you can expect anything from strings to `numpy.array`.
+        """
+
+
+class LoggerReporter(Reporter):
+    """Reporter for logging.
+
+    This Reporter is responsible for setting up a Logger object and logging all
+    events that happened during circle-evolution cycle. Notice that this
+    reporter only cares about strings and will notify minimal details about
+    other types.
+    """
+    def setup(self):
+        """Sets up Logger"""
+        config_initial = {
+            'version': 1,
+            'disable_existing_loggers': True,
+            'formatters': {
+                'simple': {
+                    'format': '%(asctime)s %(name)s %(message)s'
+                },
+            },
+            'handlers': {
+                'console': {
+                    'level': 'INFO',
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'simple'
+                },
+            },
+            'loggers': {
+                'circle-evolution': {
+                    'handlers': ['console'],
+                    'level': 'DEBUG',
+                }
+            },
+            'root': {
+                'handlers': ['console'],
+                'level': 'DEBUG'
+            }
+        }
+        logging.config.dictConfig(config_initial)
+        self.logger = logging.getLogger(__name__)  # Creating new logger
+
+    def update(self, report):
+        """Logs events using logger"""
+        self.logger.debug("Received event...")
+        if isinstance(report, str):
+            # Only deals with string messages
+            self.logger.info(report)

--- a/circle_evolution/reporter.py
+++ b/circle_evolution/reporter.py
@@ -17,6 +17,7 @@ class Reporter(ABC):
     them for visualization. Please, use this class if you want to implement
     your own Reporter.
     """
+
     def __init__(self):
         """Initialization calls setup to configure Reporter"""
         self.setup()
@@ -46,33 +47,16 @@ class LoggerReporter(Reporter):
     reporter only cares about strings and will notify minimal details about
     other types.
     """
+
     def setup(self):
         """Sets up Logger"""
         config_initial = {
-            'version': 1,
-            'disable_existing_loggers': True,
-            'formatters': {
-                'simple': {
-                    'format': '%(asctime)s %(name)s %(message)s'
-                },
-            },
-            'handlers': {
-                'console': {
-                    'level': 'INFO',
-                    'class': 'logging.StreamHandler',
-                    'formatter': 'simple'
-                },
-            },
-            'loggers': {
-                'circle-evolution': {
-                    'handlers': ['console'],
-                    'level': 'DEBUG',
-                }
-            },
-            'root': {
-                'handlers': ['console'],
-                'level': 'DEBUG'
-            }
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {"simple": {"format": "%(asctime)s %(name)s %(message)s"}},
+            "handlers": {"console": {"level": "INFO", "class": "logging.StreamHandler", "formatter": "simple"}},
+            "loggers": {"circle-evolution": {"handlers": ["console"], "level": "DEBUG"}},
+            "root": {"handlers": ["console"], "level": "DEBUG"},
         }
         logging.config.dictConfig(config_initial)
         self.logger = logging.getLogger(__name__)  # Creating new logger

--- a/circle_evolution/reporter.py
+++ b/circle_evolution/reporter.py
@@ -34,7 +34,26 @@ class Reporter(ABC):
         """Receives report from subject.
 
         This is the main function for reporting events. The Reporter receives a
-        report and have to deal with what to do with that.
+        report and have to deal with what to do with that. To accomodate with
+        context, it also receives an status.
+        """
+
+    @abstractmethod
+    def on_start(self, report):
+        """Receives report for when the Subject start processing.
+
+        If a reporter needs to report an object being initialized or starts
+        processing, it can use this. Please note that ALL reporters need
+        to implement this, if it is not used you can just `return` or `pass`
+        """
+
+    @abstractmethod
+    def on_stop(self, report):
+        """Receives report for when the Subject finishes processing.
+
+        If a reporter needs to report an object that finished
+        processing, it can use this. Please note that ALL reporters need
+        to implement this, if it is not used you can just `return` or `pass`
         """
 
 
@@ -74,3 +93,9 @@ class LoggerMetricReporter(Reporter):
         self.logger.info(
             "Generation %s - Fitness %.5f - Improvement %.5f%%", report.generation, report.current_fitness, improvement
         )
+
+    def on_start(self, report):
+        """Just logs the maximum generations"""
+
+    def on_stop(self, report):
+        """Just logs the final fitness"""

--- a/circle_evolution/reporter.py
+++ b/circle_evolution/reporter.py
@@ -108,7 +108,7 @@ class LoggerMetricReporter(Reporter):
             self.logger.info(message)
         else:
             message += " - No Improvement"
-            self.logger.info(message)
+            self.logger.debug(message)
 
     def on_start(self, report):
         """Just logs the maximum generations"""

--- a/circle_evolution/runner.py
+++ b/circle_evolution/runner.py
@@ -4,6 +4,10 @@ If you want to receive reports about any objects in Circle-Evolution you just
 need to extend your class with the base Runner. It provides an interface for
 attaching reporters and notifying all reporters of a particular event.
 """
+# Constants for Runners
+START = 0
+PROCESSING = 1
+END = 2
 
 
 class Runner:
@@ -23,14 +27,14 @@ class Runner:
         """Attaches reporter for notifications"""
         self._reporters.append(reporter)
 
-    def notify(self, report, status="processing"):
+    def notify(self, report, status=PROCESSING):
         """Send report to all attached reporters"""
-        if status == "start":
+        if status == START:
             for reporter in self._reporters:
                 reporter.on_start(report)
-        elif status == "end":
+        elif status == END:
             for reporter in self._reporters:
                 reporter.on_stop(report)
-        else:
+        elif status == PROCESSING:
             for reporter in self._reporters:
                 reporter.update(report)

--- a/circle_evolution/runner.py
+++ b/circle_evolution/runner.py
@@ -1,0 +1,28 @@
+"""Base Class for Reported Objects.
+
+If you want to receive reports about any objects in Circle-Evolution you just
+need to extend your class with the base Runner. It provides an interface for
+attaching reporters and notifying all reporters of a particular event.
+"""
+
+
+class Runner:
+    """Base Runner class.
+
+    The Runner class is responsible for managing reporters and sending events
+    to them. If you need to receive updates by a particular reporter you just
+    need to use this base class.
+
+    Attributes:
+        _reporters: list of reporters that are going to receive reports.
+    """
+    _reporters = []
+
+    def attach(self, reporter):
+        """Attaches reporter for notifications"""
+        self._reporters.append(reporter)
+
+    def notify(self, report):
+        """Send report to all attached reporters"""
+        for reporter in self._reporters:
+            reporter.update(report)

--- a/circle_evolution/runner.py
+++ b/circle_evolution/runner.py
@@ -23,7 +23,14 @@ class Runner:
         """Attaches reporter for notifications"""
         self._reporters.append(reporter)
 
-    def notify(self, report):
+    def notify(self, report, status="processing"):
         """Send report to all attached reporters"""
-        for reporter in self._reporters:
-            reporter.update(report)
+        if status == "start":
+            for reporter in self._reporters:
+                reporter.on_start(report)
+        elif status == "end":
+            for reporter in self._reporters:
+                reporter.on_stop(report)
+        else:
+            for reporter in self._reporters:
+                reporter.update(report)

--- a/circle_evolution/runner.py
+++ b/circle_evolution/runner.py
@@ -16,6 +16,7 @@ class Runner:
     Attributes:
         _reporters: list of reporters that are going to receive reports.
     """
+
     _reporters = []
 
     def attach(self, reporter):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ with open("circle_evolution/__init__.py", "rt", encoding="utf8") as f:
     # Normalize version so `setup.py --version` show same version as twine.
     version = str(packaging.version.Version(version))
 
+with open("README.md", "r") as reader:
+    long_description = reader.read()
+
 # Library dependencies
 INSTALL_REQUIRES = ["opencv-python==4.2.0.34", "numpy==1.18.4", "matplotlib==3.2.1", "scikit-image==0.17.2"]
 
@@ -32,6 +35,7 @@ setup(
     name="circle_evolution",
     version=version,
     description="Evolutionary Art Using Circles",
+    long_description=long_description,
     url="https://github.com/ahmedkhalf/Circle-Evolution/",
     packages=find_packages(),
     download_url="https://github.com/ahmedkhalf/Circle-Evolution/archive/v0.1.tar.gz",


### PR DESCRIPTION
Observer Pattern for Reporters and Runners

## Description

I've added a Base Reporter class, in which you should provide a way to set up the reporter and deal with incoming events. I also add an Example using a LoggerReporter that only deals with string events and logs them to the screen.

To deal with Subjects I've implemented a base Runner class that already implements the observer's attach and notify functions.

## Motivation and Context

Closes #12 
Implements BaseReporter.

## How Has This Been Tested?

Now, the CLI uses the LoggerReporter to log the generation fitness, instead of using the print function.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
