### PR TITLE
CLI option change: removing unnecessary --size option and auto-detect instead image size - close #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ You can easily start training an image by calling circle_evolution from your ter
 
 **Example:**
 ```bash
-circle_evolution "Mona Lisa 64.jpg" --genes 256 --max-generations 50000
+circle_evolution "Mona Lisa 64.jpg" --size 1 --genes 256 --max-generations 50000
 ```
 
 | Parameter         | Description                                                          |
 | ----------------- | -------------------------------------------------------------------- |
+| --size            | Image size {1: (64, 64), 2: (128, 128), 3: (256, 256)}. *Default: 2* |
 | --genes           | Number of circle to fit. *Default: 256*                              |
 | --max-generations | Number of generations to run. *Default: 500,000*                     |
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ You can easily start training an image by calling circle_evolution from your ter
 
 **Example:**
 ```bash
-circle_evolution "Mona Lisa 64.jpg" --size 1 --genes 256 --max-generations 50000
+circle_evolution "Mona Lisa 64.jpg" --genes 256 --max-generations 50000
 ```
 
 | Parameter         | Description                                                          |
 | ----------------- | -------------------------------------------------------------------- |
-| --size            | Image size {1: (64, 64), 2: (128, 128), 3: (256, 256)}. *Default: 2* |
 | --genes           | Number of circle to fit. *Default: 256*                              |
 | --max-generations | Number of generations to run. *Default: 500,000*                     |
 

--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -9,18 +9,23 @@ from circle_evolution.evolution import Evolution
 import circle_evolution.helpers as helpers
 
 
+SIZE_OPTIONS = {1: (64, 64), 2: (128, 128), 3: (256, 256), 'auto': None}
+
+
 def main():
     """Entrypoint of application"""
     parser = argparse.ArgumentParser(description="Circle Evolution CLI")
 
     parser.add_argument("image", type=str, help="Image to be processed")
+    parser.add_argument("--size", choices=SIZE_OPTIONS.keys(), default='auto', help="Dimension of the image")
     parser.add_argument("--genes", default=256, type=int, help="Number of genes")
     parser.add_argument("--max-generations", type=int, default=500000)
     args = parser.parse_args()
 
-    target = helpers.load_target_image(args.image)
+    target = helpers.load_target_image(args.image, size=size_options[args.size])
 
-    evolution = Evolution(target.shape, target, genes=args.genes)
+    output_img_dimensions = size_options[args.size] or target.shape
+    evolution = Evolution(output_img_dimensions, target, genes=args.genes)
     evolution.evolve(max_generation=args.max_generations)
 
     evolution.specie.render()

--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -22,9 +22,9 @@ def main():
     parser.add_argument("--max-generations", type=int, default=500000)
     args = parser.parse_args()
 
-    target = helpers.load_target_image(args.image, size=size_options[args.size])
+    target = helpers.load_target_image(args.image, size=SIZE_OPTIONS[args.size])
 
-    output_img_dimensions = size_options[args.size] or target.shape
+    output_img_dimensions = SIZE_OPTIONS[args.size] or target.shape
     evolution = Evolution(output_img_dimensions, target, genes=args.genes)
     evolution.evolve(max_generation=args.max_generations)
 

--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -1,4 +1,4 @@
-"""CLI interface for Circle Evolution"""
+"""CLI for Circle Evolution"""
 
 import argparse
 
@@ -14,15 +14,13 @@ def main():
     parser = argparse.ArgumentParser(description="Circle Evolution CLI")
 
     parser.add_argument("image", type=str, help="Image to be processed")
-    size_options = {1: (64, 64), 2: (128, 128), 3: (256, 256)}
-    parser.add_argument("--size", choices=size_options.keys(), default=2, help="Dimension of the image", type=int)
     parser.add_argument("--genes", default=256, type=int, help="Number of genes")
     parser.add_argument("--max-generations", type=int, default=500000)
     args = parser.parse_args()
 
-    target = helpers.load_target_image(args.image, size=size_options[args.size])
+    target = helpers.load_target_image(args.image)
 
-    evolution = Evolution(size_options[args.size], target, genes=args.genes)
+    evolution = Evolution(target.shape, target, genes=args.genes)
     evolution.evolve(max_generation=args.max_generations)
 
     evolution.specie.render()


### PR DESCRIPTION
## Description
This PR is a suggested change in order to address https://github.com/ahmedkhalf/Circle-Evolution/issues/16
I went for the most simple solution : remove the `--size` CLI flag and auto-detect the actual image size.
This seemed the best to keep the simplicity of the CLI utility, but please tell me if I missed some useful usages of `--size` !

## Motivation and Context
Generates images with the same dimensions as the input image by default

## How Has This Been Tested?
Tested manually on 320x640 image.
It works well but seems to make the program slower.

## Screenshots (if appropriate):

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
