### PR TITLE
CLI: include release version when getting --help

### DIFF
--- a/circle_evolution/main.py
+++ b/circle_evolution/main.py
@@ -4,6 +4,7 @@ import argparse
 
 import numpy as np
 
+from circle_evolution import __version__
 from circle_evolution.evolution import Evolution
 
 import circle_evolution.helpers as helpers
@@ -14,7 +15,7 @@ SIZE_OPTIONS = {1: (64, 64), 2: (128, 128), 3: (256, 256), 'auto': None}
 
 def main():
     """Entrypoint of application"""
-    parser = argparse.ArgumentParser(description="Circle Evolution CLI")
+    parser = argparse.ArgumentParser(description=f"Circle Evolution CLI v{__version__}")
 
     parser.add_argument("image", type=str, help="Image to be processed")
     parser.add_argument("--size", choices=SIZE_OPTIONS.keys(), default='auto', help="Dimension of the image")


### PR DESCRIPTION
## Motivation and Context
Just seems useful to me

## How Has This Been Tested?
Manually, by using the `--help` argument

## Screenshots (if appropriate):
```
$ circle_evolution --help
usage: circle_evolution [-h] [--size {1,2,3,auto}] [--genes GENES] [--max-generations MAX_GENERATIONS] image

Circle Evolution CLI v0.1
...
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [NA] My change requires a change to the documentation
- [NA] I have updated the documentation accordingly.
